### PR TITLE
Autostart service

### DIFF
--- a/GUI/AltServer.sh
+++ b/GUI/AltServer.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run as root."
+    exit
+fi
+
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+cat <<EOF | tee AltServer.desktop >/dev/null
+[Desktop Entry]
+Name=AltServer
+GenericName=AltServer for AltStore
+Exec="$SCRIPT_DIR/AltServerGUI"
+Terminal=false
+Type=Application
+X-GNOME-Autostart-enabled=true
+EOF
+
+sudo cp AltServer.desktop /home/*/.config/autostart/
+sudo rm AltServer.desktop


### PR DESCRIPTION
Basic script to run AltServer at boot.
Tested on Ubuntu 20.04, on AltServerGUI 0.1 build.

Script needs to be run in the same folder as AltServerGUI.
Script can probably be added to a build and then ran on first launch to add script to autostart.