### PR TITLE
Reformat code, hide password input and fix reinstall AltStore works for existed UDID

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -8,7 +8,6 @@ from PyQt5.QtWidgets import *
 from PySide2 import QtCore
 import subprocess
 import requests
-import glob
 import os
 import sys
 
@@ -21,18 +20,19 @@ cwd = os.getcwd()
 AltServer = resource_path("AltServer")
 AutoStart = resource_path("AutoStart.sh")
 Exec = cwd+"/altserver"
-UserName = subprocess.check_output("whoami",shell=True).decode('utf-8').replace("\n", "")
+UserName = os.getlogin()
 
 def internet_stat():
     timeout = 5
     try:
         requests.get("https://github.com", timeout=timeout)
         return True
-    except (requests.ConnectionError, requests.Timeout) as exception:
+    except (requests.ConnectionError, requests.Timeout):
 	    return False
 
 # Version 
-LocalVersion=subprocess.check_output("sed -n 1p %s" %resource_path("version"),shell=True).decode('utf-8').replace("\n", "")
+with open(resource_path("version"), 'r', encoding='utf-8') as f:
+    LocalVersion = f.readline().strip()
 LatestVersion=""
 
 # Function part
@@ -41,8 +41,15 @@ def about_message():
     msg_box = QMessageBox()
     msg_box.setIconPixmap(QPixmap(resource_path("Icon@128.png")))
     msg_box.setWindowTitle('AltServer-Linux')
-    msg_box.setInformativeText('GUI by powenn on Github\n\nAltServer-Linux by NyaMisty on Github\n\nNot offical AltServer from Riley Testut\nVersion : %s' %LocalVersion)
-    msg_box.setDetailedText('Source code :\nhttps://github.com/powenn/AltServer-LinuxGUI\nFor questions about this GUI, you can contact @powen00hsiao on Twitter')
+    msg_box.setInformativeText(
+        'GUI by powenn on Github\n\n'
+        'AltServer-Linux by NyaMisty on Github\n\n'
+        'Not offical AltServer from Riley Testut\n'
+        f'Version : {LocalVersion}')
+    msg_box.setDetailedText(
+        'Source code :\n'
+        'https://github.com/powenn/AltServer-LinuxGUI'
+        'For questions about this GUI, you can contact @powen00hsiao on Twitter')
     msg_box.exec()
 
 @QtCore.Slot()
@@ -50,18 +57,24 @@ def Installation():
     DeviceCheck=subprocess.run('idevicepair pair',shell=True)
     if DeviceCheck.returncode == 1 :
         errmsg_box = QMessageBox()
-        errmsg_box.setText('Please make sure connected to your device\n\nAnd accept the trust dialog on the screen of the device, then attempt to pair again.')
+        errmsg_box.setText(
+            'Please make sure connected to your device\n\n'
+            'And accept the trust dialog on the screen of the device, then attempt to pair again.')
         errmsg_box.exec()
     if DeviceCheck.returncode == 0 :
-        PATH=resource_path("AltStore.ipa")
-        UDID=subprocess.check_output("lsusb -v 2> /dev/null | grep -e 'Apple Inc' -A 2 | grep iSerial | awk '{print $3}'",shell=True).decode('utf-8').replace("\n", "")
+        PATH = resource_path("AltStore.ipa")
+        _udid = subprocess.check_output("lsusb -v 2> /dev/null | grep -e 'Apple Inc' -A 2 | grep iSerial | awk '{print $3}'",shell=True).decode().strip()
+        UDID = _udid[:8] + '-' + _udid[8:]
         AccountArea=QDialog()
         Layout = QVBoxLayout()
-        Privacy_msg = QLabel("Your Apple ID and password are not saved\nand are only sent to Apple for authentication.")
+        Privacy_msg = QLabel(
+            "Your Apple ID and password are not saved\n"
+            "and are only sent to Apple for authentication.")
         Privacy_msg.setFont(QFont('Arial', 10))
         label = QLabel("Please Enter your Apple ID and password")
         IDInputArea = QLineEdit(placeholderText="Apple ID")
         PasswordInputArea = QLineEdit(placeholderText="Password")
+        PasswordInputArea.setEchoMode(QLineEdit.EchoMode.Password)
         btn = QPushButton()
         Success_msg = QSystemTrayIcon()  
 
@@ -69,33 +82,33 @@ def Installation():
             AccountArea.close()
             AppleID=IDInputArea.text()
             Password=PasswordInputArea.text()
-            InsAltStoreCMD='%s -u %s -a %s -p %s %s > %s' % (resource_path("AltServer"),UDID,AppleID,Password,PATH,resource_path("log.txt"))
+            InsAltStoreCMD=f'{resource_path("AltServer")} -u {UDID} -a {AppleID} -p {Password} {PATH} > {resource_path("log.txt")}'
             Installing = True
             WarnTime=0
             InsAltStore=subprocess.Popen(InsAltStoreCMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
             while Installing :   
-                CheckIns=subprocess.run('grep "Installation Failed" %s' %resource_path("log.txt"),shell=True)
-                CheckWarn=subprocess.run('grep "Are you sure you want to continue?" %s' %resource_path("log.txt"),shell=True)
-                CheckSuccess=subprocess.run('grep "Installation Succeeded" %s' %resource_path("log.txt"),shell=True)
-                Check2fa=subprocess.run('grep "Requires two factor..." %s' %resource_path("log.txt"),shell=True)
+                CheckIns=subprocess.run(f'grep "Installation Failed" {resource_path("log.txt")}',shell=True)
+                CheckWarn=subprocess.run(f'grep "Are you sure you want to continue?" {resource_path("log.txt")}',shell=True)
+                CheckSuccess=subprocess.run(f'grep "Installation Succeeded" {resource_path("log.txt")}',shell=True)
+                Check2fa=subprocess.run(f'grep "Requires two factor..." {resource_path("log.txt")}',shell=True)
 
                 if CheckIns.returncode == 0 :
                     Installing = False
                     InsAltStore.terminate()
-                    Failmsg=subprocess.check_output("tail -6 %s" %resource_path("log.txt"),shell=True).decode('utf-8')
+                    Failmsg=subprocess.check_output(f"tail -6 {resource_path('log.txt')}",shell=True).decode()
                     Failmsg_box = QMessageBox()
                     Failmsg_box.setText(Failmsg)
                     Failmsg_box.exec()
                 if CheckWarn.returncode == 0 and WarnTime == 0 :
-                    Warnmsg=subprocess.check_output("tail -8 %s" %resource_path("log.txt"),shell=True).decode('utf-8')
+                    Warnmsg=subprocess.check_output(f"tail -8 {resource_path('log.txt')}",shell=True).decode()
                     Warnmsg_box = QMessageBox()
                     buttonReply = QMessageBox.warning(Warnmsg_box, 'Alert', Warnmsg, QMessageBox.Yes | QMessageBox.No,QMessageBox.Yes)
                     if buttonReply == QMessageBox.Yes:
                         InsAltStore.communicate(input=b'\n')
                     
-                    if buttonReply == QMessageBox.No :
+                    if buttonReply == QMessageBox.No:
                         Installing = False
-                        os.system('pkill -TERM -P {pid}'.format(pid=InsAltStore.pid)) 
+                        os.system(f'pkill -TERM -P {InsAltStore.pid}') 
                         Cancelmsg_box = QMessageBox()
                         Cancelmsg_box.setText("Installation Canceled")
                         Cancelmsg_box.exec()
@@ -127,7 +140,7 @@ def Installation():
                 if CheckSuccess.returncode == 0 :
                     Installing = False
                     Success_msg.setVisible(True)
-                    Success_msg.showMessage("Installation Succeded","AltStore was successfully installed",QSystemTrayIcon.Information,200)
+                    Success_msg.showMessage("Installation Succeded","AltStore was successfully installed", QSystemTrayIcon.Information,200)
 
         btn.setText("Install")
         btn.clicked.connect(ButtonClicked)
@@ -145,22 +158,22 @@ def pair():
 
 @QtCore.Slot()
 def restart_daemon():
-    subprocess.run('killall %s' %AltServer,shell=True)
+    subprocess.run(f'killall {AltServer}',shell=True)
     subprocess.run('idevicepair pair',shell=True)
-    subprocess.run('%s &> /dev/null &' %AltServer,shell=True)
+    subprocess.run(f'{AltServer} &> /dev/null &',shell=True)
 
 @QtCore.Slot()
 def check_update():
     Passwd_Check_Time = 0
     if (internet_stat()) == True  :
-        LatestVersion=subprocess.check_output("curl -Lsk https://github.com/powenn/AltServer-LinuxGUI/raw/main/version",shell=True).decode('utf-8')
+        LatestVersion=subprocess.check_output("curl -Lsk https://github.com/powenn/AltServer-LinuxGUI/raw/main/version",shell=True).decode()
         if LatestVersion == LocalVersion :
             Already_latest_msg_box = QMessageBox()
             Already_latest_msg_box.setText("you are using the latest release")
             Already_latest_msg_box.exec()
         if LatestVersion != LocalVersion :
             Updatemsg_box = QMessageBox()
-            UpdateLog=subprocess.check_output("curl -Lsk https://github.com/powenn/AltServer-LinuxGUI/raw/main/updatelog.md",shell=True).decode('utf-8')
+            UpdateLog=subprocess.check_output("curl -Lsk https://github.com/powenn/AltServer-LinuxGUI/raw/main/updatelog.md",shell=True).decode()
             Updatemsg_box.setText(UpdateLog)
             buttonReply = QMessageBox.information(Updatemsg_box, 'Update now ?', UpdateLog, QMessageBox.Yes | QMessageBox.No,QMessageBox.Yes)
             if buttonReply == QMessageBox.Yes and Passwd_Check_Time == 0:
@@ -168,8 +181,9 @@ def check_update():
                 passwd_Area=QDialog()
                 passwd_Area.setWindowTitle("Requires password")
                 passwd_Layout = QVBoxLayout()
-                passwd_label = QLabel("Please enter password for %s" %UserName)
+                passwd_label = QLabel(f"Please enter password for {UserName}")
                 Input_passwd_Area = QLineEdit(placeholderText="password")
+                Input_passwd_Area.setEchoMode(QLineEdit.EchoMode.Password)
                 send_passwd_btn = QPushButton()
 
                 def Button_passwd_Clicked():
@@ -177,20 +191,20 @@ def check_update():
                     sudo_passwd=Input_passwd_Area.text()
                     sudo_passwd=sudo_passwd+"\n"
                     sudo_passwd_bytes = bytes(sudo_passwd.encode())
-                    sudo_Check = os.system('echo "%s" | sudo -S %s' % (sudo_passwd, "echo 'check password'"))
+                    sudo_Check = os.system(f'echo "{sudo_passwd}" | sudo -S echo "check password"')
                     if sudo_Check == 0 :
                         Updating_msg_box = QSystemTrayIcon()
                         Updating_msg_box.setVisible(True)
                         Updating_msg_box.showMessage("Updating","Please wait a moment",QSystemTrayIcon.Information,200)
                         update_pyfile = cwd+"/update.py"
                         deb_file = cwd+"/AltServer.deb"
-                        subprocess.run("curl -L 'https://github.com/powenn/AltServer-LinuxGUI/raw/main/update.py' > %s" %update_pyfile,shell=True)
-                        Updating = subprocess.run("python3 %s" %update_pyfile,shell=True)
+                        subprocess.run(f"curl -L 'https://github.com/powenn/AltServer-LinuxGUI/raw/main/update.py' > {update_pyfile}",shell=True)
+                        Updating = subprocess.run(f"python3 {update_pyfile}",shell=True)
                         if Updating.returncode == 0:
-                            NewRelease_Installation = subprocess.Popen("sudo -S dpkg -i %s" %deb_file, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,shell=True)
+                            NewRelease_Installation = subprocess.Popen(f"sudo -S dpkg -i {deb_file}", stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,shell=True)
                             NewRelease_Installation.communicate(input=sudo_passwd_bytes) 
-                            subprocess.run("rm -rf %s" %deb_file,shell=True)
-                            subprocess.run("rm -rf %s" %update_pyfile,shell=True)
+                            subprocess.run(f"rm -rf {deb_file}",shell=True)
+                            subprocess.run(f"rm -rf {update_pyfile}",shell=True)
                             if NewRelease_Installation.returncode == 0 :
                                 Update_done_msg_box = QMessageBox()
                                 Update_done_msg_box.setText("Update Done\nApp will restart to apply the new version")
@@ -229,9 +243,9 @@ def check_update():
 @QtCore.Slot()
 def UpdateNotification() :
     if (internet_stat()) == True:
-        LatestVersion=subprocess.check_output("curl -Lsk https://github.com/powenn/AltServer-LinuxGUI/raw/main/version",shell=True).decode('utf-8')
+        LatestVersion=subprocess.check_output("curl -Lsk https://github.com/powenn/AltServer-LinuxGUI/raw/main/version",shell=True).decode()
         if LatestVersion != LocalVersion :
-            UpdateLog=subprocess.check_output("curl -Lsk https://github.com/powenn/AltServer-LinuxGUI/raw/main/updatelog.md",shell=True).decode('utf-8')
+            UpdateLog=subprocess.check_output("curl -Lsk https://github.com/powenn/AltServer-LinuxGUI/raw/main/updatelog.md",shell=True).decode()
             Update_Avaliable_box = QMessageBox()
             Update_Avaliable_box.setWindowTitle('UPDATE AVALIABLE')
             Update_Avaliable_box.setText(UpdateLog)

--- a/UI.py
+++ b/UI.py
@@ -4,12 +4,13 @@
 
 # import
 from Main import *
+import glob
 
 # check permission
-if subprocess.run('stat %s | grep -- "-rw-r--r--"' %AltServer,shell=True) != "" :
-    subprocess.run("chmod +x %s" %AltServer,shell=True)
-if subprocess.run('stat %s | grep -- "-rw-r--r--"' %AutoStart,shell=True) != "" :
-    subprocess.run("chmod +x %s" %AutoStart,shell=True)
+if not os.access(AltServer, os.X_OK):
+    subprocess.run(f"chmod +x {AltServer}", shell=True)
+if not os.access(AutoStart, os.X_OK):
+    subprocess.run(f"chmod +x {AutoStart}", shell=True)
 
 # UI part
 app = QApplication(sys.argv)
@@ -57,7 +58,7 @@ def launch_config() :
          launch_enable=False
     if launch_enable :
         LaunchAtLogin.setChecked(True)
-        subprocess.run("%s" %resource_path("AutoStart.sh"),shell=True)
+        subprocess.run(resource_path("AutoStart.sh"),shell=True)
     if not launch_enable :
         LaunchAtLogin.setChecked(False)
         subprocess.run("rm -rf /home/*/.config/autostart/AltServer.desktop",shell=True)
@@ -84,7 +85,7 @@ menu.addSeparator()
 
 # Add a Quit option to the menu.
 def app_quit():
-    subprocess.run('killall %s' %AltServer,shell=True)
+    subprocess.run(f'killall {AltServer}',shell=True)
     app.quit()    
 quit = QAction("Quit AltServer")
 quit.triggered.connect(app_quit)
@@ -94,6 +95,6 @@ menu.addAction(quit)
 
 # Add the menu to the tray
 tray.setContextMenu(menu)
-subprocess.run('%s &> /dev/null &' %AltServer,shell=True)
+subprocess.run(f'{AltServer} &> /dev/null &',shell=True)
 UpdateNotification()
 app.exec_()


### PR DESCRIPTION
Hi, I really like your project and I like to contribute. Please review my changes if you see it fit you:
- Fix reinstall AltStore for UDID that has been used before by adding `-` in the 8th number of the UDID string
- Replace subprocess commands with python alternatives
- Hide echo for the password input fields
- Reformat using f-string for better code readability
- Replace `.decode('utf-8')` with `.decode()` as it is the default behavior