### PR TITLE
Rewrite Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ __pycache__
 *.spec
 *.deb
 .idea/
-AltServerData

--- a/packaging/ubuntu/build_deb.sh
+++ b/packaging/ubuntu/build_deb.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cd "$(dirname "$0")" || exit
-
 # Package variables
 PACKAGE_NAME="altserver-linuxgui"
 

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,7 @@ GUI_VERSION = "0.5"
 PROGRAM_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 RESOURCES_DIRECTORY = os.path.join(PROGRAM_DIRECTORY, "resources")
 USER_DATA_DIRECTORY = os.path.expanduser(f"~/.local/share/{GUI_NAME}")
-USER_DATA_PATH = os.path.join(USER_DATA_DIRECTORY, "./")
+USER_DATA_PATH = os.path.dirname(USER_DATA_DIRECTORY)
 CONFIG_FILE_PATH = os.path.join(USER_DATA_DIRECTORY, "config.json")
 LOG_DIRECTORY = os.path.join(USER_DATA_DIRECTORY, "logs")
 

--- a/src/main.py
+++ b/src/main.py
@@ -650,14 +650,18 @@ if __name__ == "__main__":
 
     # If any of our required dependencies are not installed, exit out
     if not exec_path_check(IDEVICEPAIR_EXEC) or not exec_path_check(IDEVICE_ID_EXEC):
-        sys.exit(1)
+        no_idevicepair_message_box = QMessageBox()
+        no_idevicepair_message_box.setText("idevicepair is required to be installed")
+        no_idevicepair_message_box.exec()
 
     # If unable to connect to the internet, exit out
     if not connection_check():
-        sys.exit(1)
-
-    # Check for AltServer and AltStore updates
-    update_binaries()
+        no_network_message_box = QMessageBox()
+        no_network_message_box.setText("No network connected")
+        no_network_message_box.exec()
+    else:
+        # Check for AltServer and AltStore updates
+        update_binaries()
 
     # Initialize daemon container object
     DAEMON_OBJECT = AltServerDaemon()

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,7 @@ GUI_VERSION = "0.5"
 PROGRAM_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 RESOURCES_DIRECTORY = os.path.join(PROGRAM_DIRECTORY, "resources")
 USER_DATA_DIRECTORY = os.path.expanduser(f"~/.local/share/{GUI_NAME}")
+USER_DATA_PATH = os.path.join(USER_DATA_DIRECTORY, "./")
 CONFIG_FILE_PATH = os.path.join(USER_DATA_DIRECTORY, "config.json")
 LOG_DIRECTORY = os.path.join(USER_DATA_DIRECTORY, "logs")
 
@@ -225,7 +226,7 @@ def start_daemon():
     stop_daemon()
     logging.info(f"Starting {ALT_SERVER_LINUX_NAME} daemon")
     DAEMON_PROCESS = subprocess.Popen(ALT_SERVER_EXEC,
-                                      cwd=USER_DATA_DIRECTORY,
+                                      cwd=USER_DATA_PATH,
                                       stderr=subprocess.DEVNULL,
                                       stdout=subprocess.DEVNULL)
 
@@ -399,7 +400,7 @@ def gui_install_alt_store():
         # Start the installation process
         logging.info(f"Installing {ALT_STORE_NAME} to connected iOS device: '{connected_device_udids[0]}'")
         install_process = subprocess.Popen(install_command,
-                                           cwd=USER_DATA_DIRECTORY,
+                                           cwd=USER_DATA_PATH,
                                            stderr=subprocess.PIPE,
                                            stdin=subprocess.PIPE,
                                            stdout=subprocess.PIPE)

--- a/src/main.py
+++ b/src/main.py
@@ -87,7 +87,7 @@ def create_directory(directory_path: str, fail_exit: bool = False):
                 logging.error(f"Unable to create directory '{directory_path}', {err}")
 
             if fail_exit:
-                exit(1)
+                sys.exit(1)
 
 
 def download_file(file_url: str, output_path: str) -> bool:
@@ -224,7 +224,10 @@ def start_daemon():
 
     stop_daemon()
     logging.info(f"Starting {ALT_SERVER_LINUX_NAME} daemon")
-    DAEMON_PROCESS = subprocess.Popen(ALT_SERVER_EXEC, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+    DAEMON_PROCESS = subprocess.Popen(ALT_SERVER_EXEC,
+                                      cwd=USER_DATA_DIRECTORY,
+                                      stderr=subprocess.DEVNULL,
+                                      stdout=subprocess.DEVNULL)
 
 
 def stop_daemon():
@@ -369,7 +372,7 @@ def gui_initialization():
         GUI_PROCESS.exec_()
     except Exception as err:
         logging.error(f"Failed to initialize GUI, {err}")
-        exit(1)
+        sys.exit(1)
 
 
 def gui_install_alt_store():
@@ -396,6 +399,7 @@ def gui_install_alt_store():
         # Start the installation process
         logging.info(f"Installing {ALT_STORE_NAME} to connected iOS device: '{connected_device_udids[0]}'")
         install_process = subprocess.Popen(install_command,
+                                           cwd=USER_DATA_DIRECTORY,
                                            stderr=subprocess.PIPE,
                                            stdin=subprocess.PIPE,
                                            stdout=subprocess.PIPE)
@@ -566,7 +570,7 @@ def gui_quit():
     logging.info(f"Exiting {GUI_NAME}")
     stop_daemon()
     GUI_PROCESS.quit()
-    exit(0)
+    sys.exit(0)
 
 
 if __name__ == "__main__":
@@ -576,11 +580,11 @@ if __name__ == "__main__":
 
     # If any of our required dependencies are not installed, exit out
     if not exec_path_check(IDEVICEPAIR_EXEC) or not exec_path_check(IDEVICE_ID_EXEC):
-        exit(1)
+        sys.exit(1)
 
     # If unable to connect to the internet, exit out
     if not connection_check():
-        exit(1)
+        sys.exit(1)
 
     # If AltServer or AltStore binaries are absent, download them
     if not os.path.exists(ALT_SERVER_EXEC) or not os.path.exists(ALT_STORE_IPA_PATH):


### PR DESCRIPTION
## Changes
- Exits are now handled by sys.exit() for better compatibility
- Subprocess calls to AltServer now use the USER_DATA_DIRECTORY as their working directory, this should cause any files generated by AltServer to be placed in the USER_DATA_DIRECTORY

I also looked into the 'installation complete' notification issue and from what I can tell it should be triggered:
main.py Lines 416 - 426:
```
            # Install succeeded workflow
            if "Installation Succeeded" in output_line:
                logging.info(line_log_message)
                install_process.terminate()
                success_msg.setVisible(True)
                success_msg.showMessage("Installation Succeeded",
                                        "AltStore was successfully installed",
                                        QSystemTrayIcon.Information,
                                        200)
                return
```

Does the "Installation Succeeded" line end up in the log file? 
